### PR TITLE
Derive virtual hostnames from eureka.instance.appname

### DIFF
--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/eureka/SanitizingEurekaInstanceConfigBean.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/eureka/SanitizingEurekaInstanceConfigBean.java
@@ -36,19 +36,23 @@ final class SanitizingEurekaInstanceConfigBean extends EurekaInstanceConfigBean 
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
+		String providedEurekaAppname = this.getAppname();
 		super.afterPropertiesSet();
-		setVirtualHostName(determineVirtualHostName(this.virtualHostNamesBean.getVirtualHostName(), ""));
-		setSecureVirtualHostName(determineVirtualHostName(this.virtualHostNamesBean.getSecureVirtualHostName(), "secure "));
+		setVirtualHostName(determineVirtualHostName(this.virtualHostNamesBean.getVirtualHostName(), "", providedEurekaAppname));
+		setSecureVirtualHostName(determineVirtualHostName(this.virtualHostNamesBean.getSecureVirtualHostName(), "secure ", providedEurekaAppname));
+		if (providedEurekaAppname != "unknown") {
+			setAppname(providedEurekaAppname);
+		}
 	}
 
-	private String determineVirtualHostName(String provided, String type) {
-		String result = provided == null ? virtualHostnameFromSanitizedAppName(type) : provided;
-		LOGGER.info("Determined " + type + "virtual hostname '" + result + "' from provided value '" + provided + "'");
+	private String determineVirtualHostName(String providedVirtualHostname, String type, String providedEurekaAppname) {
+		String result = providedVirtualHostname == null ? virtualHostnameFromSanitizedAppNames(type, providedEurekaAppname) : providedVirtualHostname;
+		LOGGER.info("Determined " + type + "virtual hostname '" + result + "' from provided value '" + providedVirtualHostname + "' and provided Eureka appname'" + providedEurekaAppname + "'");
 		return result;
 	}
 
-	private String virtualHostnameFromSanitizedAppName(String type) {
-		String appName = this.getAppname();
+	private String virtualHostnameFromSanitizedAppNames(String type, String providedEurekaAppname) {
+		String appName = providedEurekaAppname == "unknown" ? this.getAppname() : providedEurekaAppname;
 
 		// RFC 952 defines the valid character set for hostnames.
 		final String virtualHostname = appName.replaceAll("[^0-9a-zA-Z\\-\\.]", "-");

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/eureka/SanitizingEurekaInstanceConfigBean.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/eureka/SanitizingEurekaInstanceConfigBean.java
@@ -38,28 +38,35 @@ final class SanitizingEurekaInstanceConfigBean extends EurekaInstanceConfigBean 
 	public void afterPropertiesSet() throws Exception {
 		String providedEurekaAppname = this.getAppname();
 		super.afterPropertiesSet();
-		setVirtualHostName(determineVirtualHostName(this.virtualHostNamesBean.getVirtualHostName(), "", providedEurekaAppname));
-		setSecureVirtualHostName(determineVirtualHostName(this.virtualHostNamesBean.getSecureVirtualHostName(), "secure ", providedEurekaAppname));
+
 		if (providedEurekaAppname != "unknown") {
+			if (this.virtualHostNamesBean.getVirtualHostName() == null) {
+				setVirtualHostName(providedEurekaAppname);
+			}
+			if (this.virtualHostNamesBean.getSecureVirtualHostName() == null) {
+				setSecureVirtualHostName(providedEurekaAppname);
+			}
 			setAppname(providedEurekaAppname);
+		} else {
+			setVirtualHostName(determineName(this.virtualHostNamesBean.getVirtualHostName(), "virtual hostname"));
+			setSecureVirtualHostName(determineName(this.virtualHostNamesBean.getSecureVirtualHostName(), "secure virtual hostname"));
+			setAppname(sanitizedSpringApplicationName("eureka application name"));
 		}
 	}
 
-	private String determineVirtualHostName(String providedVirtualHostname, String type, String providedEurekaAppname) {
-		String result = providedVirtualHostname == null ? virtualHostnameFromSanitizedAppNames(type, providedEurekaAppname) : providedVirtualHostname;
-		LOGGER.info("Determined " + type + "virtual hostname '" + result + "' from provided value '" + providedVirtualHostname + "' and provided Eureka appname'" + providedEurekaAppname + "'");
-		return result;
+	private String determineName(String providedName, String type) {
+		return providedName == null ? sanitizedSpringApplicationName(type) : providedName;
 	}
 
-	private String virtualHostnameFromSanitizedAppNames(String type, String providedEurekaAppname) {
-		String appName = providedEurekaAppname == "unknown" ? this.getAppname() : providedEurekaAppname;
+	private String sanitizedSpringApplicationName(String type) {
+		String appName = this.getAppname();
 
 		// RFC 952 defines the valid character set for hostnames.
 		final String virtualHostname = appName.replaceAll("[^0-9a-zA-Z\\-\\.]", "-");
 
 		if (!appName.equals(virtualHostname)) {
-			// Log a warning since this sanitised virtual hostname could clash with the virtual hostname of other applications.
-			LOGGER.warning("Application name '" + appName + "' was sanitised to produce " + type + "virtual hostname '" + virtualHostname + "'");
+			// Log a warning since this sanitised name could clash with the a non-sanitised name.
+			LOGGER.warning("Spring application name '" + appName + "' was sanitised to produce " + type + " '" + virtualHostname + "'");
 		}
 
 		return virtualHostname;

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/eureka/SanitizingEurekaInstanceConfigBeanTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/eureka/SanitizingEurekaInstanceConfigBeanTest.java
@@ -179,9 +179,21 @@ public class SanitizingEurekaInstanceConfigBeanTest {
     }
 
     @Test
+    public void testVirtualHostNameDefaultsToEurekaApplicationName() {
+        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps("spring.application.name:san", "eureka.instance.appname:ean");
+        assertEquals("ean", bean.getVirtualHostName());
+    }
+
+    @Test
     public void testSecureVirtualHostNameDefaultsToApplicationName() {
         SanitizingEurekaInstanceConfigBean bean = createBeanWithProps("spring.application.name:san");
         assertEquals("san", bean.getSecureVirtualHostName());
+    }
+
+    @Test
+    public void testSecureVirtualHostNameDefaultsToEurekaApplicationName() {
+        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps("spring.application.name:san", "eureka.instance.appname:ean");
+        assertEquals("ean", bean.getSecureVirtualHostName());
     }
 
     @Test

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/eureka/SanitizingEurekaInstanceConfigBeanTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/eureka/SanitizingEurekaInstanceConfigBeanTest.java
@@ -173,46 +173,31 @@ public class SanitizingEurekaInstanceConfigBeanTest {
     }
 
     @Test
-    public void testVirtualHostNameDefaultsToApplicationName() {
-        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps("spring.application.name:san");
+    public void testAppIdentifiersAreDefaultedIfOnlySpringAppNameIsSet() {
+        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps(
+                "spring.application.name:san");
+        assertEquals("san", bean.getAppname());
         assertEquals("san", bean.getVirtualHostName());
-    }
-
-    @Test
-    public void testVirtualHostNameDefaultsToEurekaApplicationName() {
-        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps("spring.application.name:san", "eureka.instance.appname:ean");
-        assertEquals("ean", bean.getVirtualHostName());
-    }
-
-    @Test
-    public void testSecureVirtualHostNameDefaultsToApplicationName() {
-        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps("spring.application.name:san");
         assertEquals("san", bean.getSecureVirtualHostName());
     }
 
     @Test
-    public void testSecureVirtualHostNameDefaultsToEurekaApplicationName() {
-        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps("spring.application.name:san", "eureka.instance.appname:ean");
-        assertEquals("ean", bean.getSecureVirtualHostName());
-    }
-
-    @Test
-    public void testDefaultVirtualHostNameIsSanitised() {
-        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps("spring.application.name:s_an");
+    public void testAppIdentifiersAreSanitisedIfOnlySpringAppNameIsSet() {
+        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps(
+                "spring.application.name:s_an");
+        assertEquals("s-an", bean.getAppname());
         assertEquals("s-an", bean.getVirtualHostName());
-    }
-
-    @Test
-    public void testDefaultSecureVirtualHostNameIsSanitised() {
-        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps("spring.application.name:s_an");
         assertEquals("s-an", bean.getSecureVirtualHostName());
     }
 
     @Test
-    public void testApplicationNameIsNotSanitised() {
-        // Virtual hostnames should be sanitised without affecting the application name.
-        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps("spring.application.name:s_an");
-        assertEquals("s_an", bean.getAppname());
+    public void testAppIdentifiersDefaultToEurekaAppName() {
+        SanitizingEurekaInstanceConfigBean bean = createBeanWithProps(
+                "spring.application.name:s_an",
+                "eureka.instance.appname:e_an");
+        assertEquals("e_an", bean.getAppname());
+        assertEquals("e_an", bean.getVirtualHostName());
+        assertEquals("e_an", bean.getSecureVirtualHostName());
     }
 
     private SanitizingEurekaInstanceConfigBean createBeanWithProps(String... pairs) {


### PR DESCRIPTION
Make it easier to set eureka.instance.appname, virtualHostname, and
secureVirtualHostname to the same value by using eureka.instance.appname for
all three values when it is provided.

Spring Cloud Netflix 1.2.2.RELEASE (part of Camden SR2) overwrites
eureka.instance.appname and both virtual hostnames with
spring.application.name if the latter is provided. This has been fixed for
1.2.4.RELEASE. Meanwhile, this commit ensures that, if eureka.instance.appname
is provided, it takes precedence over spring.application.name.

[#133115289, #135258295]