### PR TITLE
Use the correct environment variable for cf app GUID

### DIFF
--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/eureka/EurekaInstanceAutoConfiguration.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/eureka/EurekaInstanceAutoConfiguration.java
@@ -65,7 +65,7 @@ public class EurekaInstanceAutoConfiguration {
 	@Value("${spring.application.name:unknown}")
 	private String appname = "unknown";
 
-	@Value("${cf.instance.guid:}")
+	@Value("${vcap.application.application_id:}")
 	private String cfAppGuid;
 
 	@Value("${cf.instance.index:}")


### PR DESCRIPTION
$CF_INSTANCE_GUID turns out not to be the cf app GUID which is actually
$recorded in VCAP_APPLICATION (under "application_id").

See https://github.com/cloudfoundry/docs-dev-guide/issues/142.

[#135521041]