### PR TITLE
Add surgical routing header to ribbon requests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ allprojects {
 	group = "io.pivotal.spring.cloud"
 
 	ext.springBootVersion = "1.4.2.RELEASE"
-	ext.springCloudVersion = "Camden.SR3"
+	ext.springCloudVersion = "Camden.SR4"
 	ext.lombokVersion = "1.16.8"
 
 	apply plugin: "propdeps"
@@ -160,6 +160,7 @@ project(":spring-cloud-services-spring-connector") {
 		testCompile("org.springframework.cloud:spring-cloud-starter-hystrix")
 		testCompile("org.springframework.cloud:spring-cloud-netflix-hystrix-stream")
 		testCompile("org.springframework.cloud:spring-cloud-starter-stream-rabbit")
+		testCompile("org.springframework.cloud:spring-cloud-starter-ribbon")
 		testCompile("commons-logging:commons-logging")
 	}
 }

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/eureka/EurekaInstanceAutoConfiguration.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/eureka/EurekaInstanceAutoConfiguration.java
@@ -54,8 +54,6 @@ public class EurekaInstanceAutoConfiguration {
 	private static final String DEFAULT_ZONE_PROPERTY = "eureka.client.serviceUrl.defaultZone";
 	private static final String ROUTE_REGISTRATION_METHOD = "route";
 	private static final String DIRECT_REGISTRATION_METHOD = "direct";
-	private static final String CF_APP_GUID = "cfAppGuid";
-	private static final String CF_INSTANCE_INDEX = "cfInstanceIndex";
 	private static final String INSTANCE_ID = "instanceId";
 	private static final String ZONE = "zone";
 
@@ -107,6 +105,11 @@ public class EurekaInstanceAutoConfiguration {
 
 		return getDefaultRegistration();
 	}
+	
+	@Bean
+	public SurgicalRoutingRequestTransformer surgicalRoutingLoadBalancerRequestTransformer() {
+		return new SurgicalRoutingRequestTransformer();
+	}
 
 	private SanitizingEurekaInstanceConfigBean getRouteRegistration() {
 		SanitizingEurekaInstanceConfigBean eurekaInstanceConfigBean = getDefaults();
@@ -132,8 +135,8 @@ public class EurekaInstanceAutoConfiguration {
 		eurekaInstanceConfigBean.setHostname(hostname);
 		eurekaInstanceConfigBean.setIpAddress(ip);
 		Map<String, String> metadataMap = eurekaInstanceConfigBean.getMetadataMap();
-		metadataMap.put(CF_APP_GUID, cfAppGuid);
-		metadataMap.put(CF_INSTANCE_INDEX, cfInstanceIndex);
+		metadataMap.put(SurgicalRoutingRequestTransformer.CF_APP_GUID, cfAppGuid);
+		metadataMap.put(SurgicalRoutingRequestTransformer.CF_INSTANCE_INDEX, cfInstanceIndex);
 		metadataMap.put(INSTANCE_ID, instanceId);
 		metadataMap.put(ZONE, zoneFromUri(zoneUri));
 

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/eureka/SurgicalRoutingRequestTransformer.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/eureka/SurgicalRoutingRequestTransformer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pivotal.spring.cloud.service.eureka;
+
+import java.util.Map;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerRequestTransformer;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.support.HttpRequestWrapper;
+
+/**
+ * Adds a surgical routing header to the request if CF App GUID and CF Instance
+ * Index are present in metadata.
+ * 
+ * @see <a href=
+ *      'https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#surgical-routing'>
+ *      https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#
+ *      surgical-routing</a>
+ * 
+ * @author William Tran
+ */
+public class SurgicalRoutingRequestTransformer implements LoadBalancerRequestTransformer {
+	public static final String CF_APP_GUID = "cfAppGuid";
+	public static final String CF_INSTANCE_INDEX = "cfInstanceIndex";
+	public static final String SURGICAL_ROUTING_HEADER = "X-CF-APP-INSTANCE";
+
+	@Override
+	public HttpRequest transformRequest(HttpRequest request, ServiceInstance instance) {
+		Map<String, String> metadata = instance.getMetadata();
+		if (metadata.containsKey(CF_APP_GUID) && metadata.containsKey(CF_INSTANCE_INDEX)) {
+			final String headerValue = String.format("%s:%s", metadata.get(CF_APP_GUID), metadata.get(CF_INSTANCE_INDEX));
+			// request.getHeaders might be immutable, so return a wrapper
+			return new HttpRequestWrapper(request) {
+				@Override
+				public HttpHeaders getHeaders() {
+					HttpHeaders headers = new HttpHeaders();
+					headers.putAll(super.getHeaders());
+					headers.add(SURGICAL_ROUTING_HEADER, headerValue);
+					return headers;
+				}
+			};
+		}
+		return request;
+	}
+
+}

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/eureka/SurgicalRoutingRequestTransformerIntegrationTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/eureka/SurgicalRoutingRequestTransformerIntegrationTest.java
@@ -1,0 +1,79 @@
+package io.pivotal.spring.cloud.service.eureka;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerRequestFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = SurgicalRoutingRequestTransformerIntegrationTest.TestConfig.class, properties = {
+		"vcap.application.uris[0]=www.route.local"
+})
+public class SurgicalRoutingRequestTransformerIntegrationTest {
+	@Mock
+	private HttpRequest originalRequest;
+	@Mock
+	private ClientHttpRequestExecution execution;
+	@Mock
+	private ServiceInstance instance;
+
+	private byte[] body = new byte[] {};
+	
+	@Autowired
+	private LoadBalancerRequestFactory lbReqFactory;
+
+	@Test
+	public void transformer() throws Exception {
+		Map<String, String> metadata = new HashMap<>();
+		metadata.put("cfAppGuid", "123");
+		metadata.put("cfInstanceIndex", "4");
+		HttpHeaders originalHeaders = new HttpHeaders();
+		originalHeaders.add("foo", "bar");
+		originalHeaders.add("foo", "baz");
+		Mockito.when(instance.getMetadata()).thenReturn(metadata);
+		Mockito.when(originalRequest.getHeaders()).thenReturn(originalHeaders);
+
+		lbReqFactory.createRequest(originalRequest, body, execution).apply(instance);
+
+		ArgumentCaptor<HttpRequest> httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+		verify(execution).execute(httpRequestCaptor.capture(), eq(body));
+		HttpRequest transformedRequest = httpRequestCaptor.getValue();
+		assertThat(transformedRequest.getHeaders().get("foo"), contains("bar", "baz"));
+		assertEquals("123:4", transformedRequest.getHeaders().getFirst("X-CF-APP-INSTANCE"));
+	}
+
+	@SpringBootApplication
+	@EnableDiscoveryClient
+	static class TestConfig {
+
+		@LoadBalanced
+		@Bean
+		public RestTemplate restTemplate() {
+			return new RestTemplate();
+		}
+	}
+
+}

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/eureka/SurgicalRoutingRequestTransformerTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/eureka/SurgicalRoutingRequestTransformerTest.java
@@ -1,0 +1,66 @@
+package io.pivotal.spring.cloud.service.eureka;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SurgicalRoutingRequestTransformerTest {
+
+	private SurgicalRoutingRequestTransformer transformer = new SurgicalRoutingRequestTransformer();
+	@Mock
+	private ServiceInstance instance;
+	@Mock
+	private HttpRequest request;
+	private HttpHeaders existingHeaders;
+
+	@Before
+	public void setup() {
+		existingHeaders = new HttpHeaders();
+		existingHeaders.add("foo", "bar");
+		existingHeaders.add("foo", "baz");
+		when(request.getHeaders()).thenReturn(HttpHeaders.readOnlyHttpHeaders(existingHeaders));
+	}
+
+	@Test
+	public void headerIsSetWhenMetadataPresent() {
+		Map<String, String> metadata = new HashMap<>();
+		metadata.put("cfAppGuid", "123");
+		metadata.put("cfInstanceIndex", "4");
+		Mockito.when(instance.getMetadata()).thenReturn(metadata);
+
+		HttpRequest transformedRequest = transformer.transformRequest(request, instance);
+
+		assertThat(transformedRequest.getHeaders().get("foo"), contains("bar", "baz"));
+		assertEquals("123:4", transformedRequest.getHeaders().getFirst("X-CF-APP-INSTANCE"));
+
+	}
+
+	@Test
+	public void headerIsNotSetWhenMetadataNotPresent() {
+		Mockito.when(instance.getMetadata()).thenReturn(Collections.emptyMap());
+
+		HttpRequest transformedRequest = transformer.transformRequest(request, instance);
+
+		assertThat(transformedRequest.getHeaders().get("foo"), contains("bar", "baz"));
+		Assert.assertNull(transformedRequest.getHeaders().getFirst("X-CF-APP-INSTANCE"));
+
+	}
+
+}


### PR DESCRIPTION
Uses new support from
https://github.com/spring-cloud/spring-cloud-commons/issues/162 to
populate the header if CF app GUID and instance index are in the chosen
instance's metadata. 

[finishes #135521917]