### PR TITLE
Conditionally disable RabbitMQ auto-configuration. [Finishes #138754683]

### DIFF
--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/config/java/ServiceInfoPropertySourceAdapter.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/config/java/ServiceInfoPropertySourceAdapter.java
@@ -8,7 +8,6 @@ import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.PropertySource;
-import org.springframework.core.env.StandardEnvironment;
 
 /**
  * Transforms a {@link ServiceInfo} into a {@link PropertySource} with highest precedence

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/hystrix/HystrixStreamServiceConnectorIntegrationTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/hystrix/HystrixStreamServiceConnectorIntegrationTest.java
@@ -16,82 +16,110 @@
 
 package io.pivotal.spring.cloud.service.hystrix;
 
+import static io.pivotal.spring.cloud.service.hystrix.HystrixStreamServiceConnector.*;
+
 import java.io.IOException;
 import java.util.Arrays;
 
-import io.pivotal.spring.cloud.MockCloudConnector;
-import io.pivotal.spring.cloud.service.common.EurekaServiceInfo;
-import io.pivotal.spring.cloud.service.common.HystrixAmqpServiceInfo;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.core.env.Environment;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static io.pivotal.spring.cloud.service.hystrix.HystrixStreamServiceConnector.SPRING_CLOUD_HYSTRIX_STREAM;
-import static io.pivotal.spring.cloud.service.hystrix.HystrixStreamServiceConnector.SPRING_CLOUD_STREAM_BINDERS_HYSTRIX;
-import static io.pivotal.spring.cloud.service.hystrix.HystrixStreamServiceConnector.SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ;
-import static io.pivotal.spring.cloud.service.hystrix.HystrixStreamServiceConnector.SPRING_CLOUD_STREAM_BINDINGS_HYSTRIXSTREAMOUTPUT;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
+import io.pivotal.spring.cloud.MockCloudConnector;
+import io.pivotal.spring.cloud.service.common.EurekaServiceInfo;
+import io.pivotal.spring.cloud.service.common.HystrixAmqpServiceInfo;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = {
-		HystrixStreamServiceConnectorIntegrationTest.TestConfig.class
-})
-@IntegrationTest()
 public class HystrixStreamServiceConnectorIntegrationTest {
+	
+	public static class WithoutRabbitBinding extends AbstractHystrixStreamServiceConnectorIntegrationTest {
 
-	private static final String URI = "amqp://username:password@p-rabbitmq.mydomain.com/testvhost";
+		@Test
+		public void propertySourceIsAdded() {
+			assertPropertyEquals("hystrix", SPRING_CLOUD_STREAM_BINDINGS_HYSTRIXSTREAMOUTPUT + "binder");
+			assertPropertyEquals(SPRING_CLOUD_HYSTRIX_STREAM, SPRING_CLOUD_STREAM_BINDINGS_HYSTRIXSTREAMOUTPUT + "destination");
+			assertPropertyEquals("rabbit", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX + "type");
+			assertPropertyEquals("false", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX + "inheritEnvironment");
+			assertPropertyEquals("false", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX + "defaultCandidate");
+			assertPropertyEquals("p-rabbitmq.mydomain.com:5672", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ + "addresses");
+			assertPropertyEquals("username", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ + "username");
+			assertPropertyEquals("password", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ + "password");
+			assertPropertyEquals("testvhost", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ + "virtualHost");
+			assertPropertyEquals("false", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ + "ssl.enabled");
+			assertPropertyEquals("true", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX + "environment.spring.cloud.stream.overrideCloudConnectors");
+			assertPropertyEquals("", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX + "default.prefix");
+			assertPropertyEquals("org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration", SPRING_AUTOCONFIGURE_EXCLUDE);
+		}
+		
+	}
+	
+	@TestPropertySource(properties="spring.rabbitmq.host=some_rabbit_host")
+	public static class WithRabbitBinding extends AbstractHystrixStreamServiceConnectorIntegrationTest {
 
-	@Autowired
-	private Environment environment;
+		@Test
+		public void springAutoConfigureExcludeIsNull() {
+			assertPropertyEquals(null, SPRING_AUTOCONFIGURE_EXCLUDE);
+		}
+		
+	}
+	
+	@TestPropertySource(properties="spring.autoconfigure.exclude=com.foo.Bar")
+	public static class WithExistingAutoConfigExcludes extends AbstractHystrixStreamServiceConnectorIntegrationTest {
 
-	@BeforeClass
-	@SuppressWarnings("unchecked")
-	public static void beforeClass() throws IOException {
-		when(MockCloudConnector.instance.isInMatchingCloud()).thenReturn(true);
-		when(MockCloudConnector.instance.getServiceInfos()).thenReturn(
-				Arrays.asList(
-						(ServiceInfo) new HystrixAmqpServiceInfo("circuit-breaker", URI),
-						(ServiceInfo) new EurekaServiceInfo("service-registry", "http://example.com", "clientId", "clientSecret", "http://example.com/token")
-				)
-		);
+		@Test
+		public void springAutoConfigureExcludePreservesExistingExcludes() {
+			assertPropertyEquals("org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration,com.foo.Bar", SPRING_AUTOCONFIGURE_EXCLUDE);
+		}
+		
 	}
 
-	@AfterClass
-	public static void afterClass() {
-		MockCloudConnector.reset();
+	@RunWith(SpringJUnit4ClassRunner.class)
+	@SpringApplicationConfiguration(classes = {
+			AbstractHystrixStreamServiceConnectorIntegrationTest.TestConfig.class
+	})
+	@IntegrationTest
+	public static abstract class AbstractHystrixStreamServiceConnectorIntegrationTest {
+
+		private static final String URI = "amqp://username:password@p-rabbitmq.mydomain.com/testvhost";
+
+		@Autowired
+		private Environment environment;
+	 
+		@BeforeClass
+		@SuppressWarnings("unchecked")
+		public static void beforeClass() throws IOException {
+			when(MockCloudConnector.instance.isInMatchingCloud()).thenReturn(true);
+			when(MockCloudConnector.instance.getServiceInfos()).thenReturn(
+					Arrays.asList(
+							(ServiceInfo) new HystrixAmqpServiceInfo("circuit-breaker", URI),
+							(ServiceInfo) new EurekaServiceInfo("service-registry", "http://example.com", "clientId", "clientSecret", "http://example.com/token")
+					)
+			);
+		}
+
+		@AfterClass
+		public static void afterClass() {
+			MockCloudConnector.reset();
+		}
+
+		protected void assertPropertyEquals(String expected, String key) {
+			assertEquals(expected, environment.getProperty(key));
+		}
+
+		@EnableCircuitBreaker
+		public static class TestConfig {
+		}
 	}
 
-	@Test
-	public void propertySourceIsAdded() {
-		assertPropertyEquals("hystrix", SPRING_CLOUD_STREAM_BINDINGS_HYSTRIXSTREAMOUTPUT + "binder");
-		assertPropertyEquals(SPRING_CLOUD_HYSTRIX_STREAM, SPRING_CLOUD_STREAM_BINDINGS_HYSTRIXSTREAMOUTPUT + "destination");
-		assertPropertyEquals("rabbit", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX + "type");
-		assertPropertyEquals("false", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX + "inheritEnvironment");
-		assertPropertyEquals("false", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX + "defaultCandidate");
-		assertPropertyEquals("p-rabbitmq.mydomain.com:5672", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ + "addresses");
-		assertPropertyEquals("username", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ + "username");
-		assertPropertyEquals("password", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ + "password");
-		assertPropertyEquals("testvhost", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ + "virtualHost");
-		assertPropertyEquals("false", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX_ENVIRONMENT_SPRING_RABBITMQ + "ssl.enabled");
-		assertPropertyEquals("true", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX + "environment.spring.cloud.stream.overrideCloudConnectors");
-		assertPropertyEquals("", SPRING_CLOUD_STREAM_BINDERS_HYSTRIX + "default.prefix");
-	}
-
-	private void assertPropertyEquals(String expected, String key) {
-		assertEquals(expected, environment.getProperty(key));
-	}
-
-	@EnableCircuitBreaker
-	public static class TestConfig {
-	}
 }


### PR DESCRIPTION
Disables normal Spring Boot auto-config for Rabbit in SCS apps bound to the circuit-breaker dashboard unless the `spring.rabbitmq.host` property is set to some value other than "localhost" (which should never be the case on PCF). 

It does this by setting the `spring.autoconfigure.exclude` property to the FQCN of the Rabbit auto-configuration class. If `spring.autoconfigure.exclude` has an existing value (presumably set by the application author) then the Rabbit auto-config class will be prepended to the list of exclusions.