### PR TITLE
Sanitize Vault properties in env endpoint. [Finishes #145874943]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ allprojects {
 	}
 
 	compileJava {
-		sourceCompatibility=1.7
-		targetCompatibility=1.7
+		sourceCompatibility=1.8
+		targetCompatibility=1.8
 	}
 	compileTestJava {
 		sourceCompatibility=1.8
@@ -146,6 +146,7 @@ project(":spring-cloud-services-spring-connector") {
 		compile(project(":spring-cloud-services-connector-core"))
 		compile("org.springframework.cloud:spring-cloud-spring-service-connector")
 		compile("org.projectlombok:lombok:${lombokVersion}")
+		compile("org.springframework.boot:spring-boot-actuator")
 		optional("org.springframework.cloud:spring-cloud-config-client")
 		optional("org.springframework.cloud:spring-cloud-netflix-eureka-client")
 		optional("com.netflix.eureka:eureka-client")

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PropertySourceMaskingConfiguration.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PropertySourceMaskingConfiguration.java
@@ -1,0 +1,19 @@
+package io.pivotal.spring.cloud.service.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.cloud.config.client.ConfigServicePropertySourceLocator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnClass(ConfigServicePropertySourceLocator.class)
+public class PropertySourceMaskingConfiguration {
+
+	@Bean
+	public PropertySourceMaskingEnvironmentEndpoint environmentEndpoint() {
+		PropertySourceMaskingEnvironmentEndpoint environmentEndpoint = new PropertySourceMaskingEnvironmentEndpoint();
+		environmentEndpoint.setSourceNamePatterns("configService:vault:*");
+		return environmentEndpoint;
+	}
+	
+}

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PropertySourceMaskingEnvironmentEndpoint.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PropertySourceMaskingEnvironmentEndpoint.java
@@ -1,5 +1,7 @@
 package io.pivotal.spring.cloud.service.config;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.actuate.endpoint.EnvironmentEndpoint;
@@ -19,7 +21,11 @@ import org.springframework.util.PatternMatchUtils;
 @ConfigurationProperties(prefix="endpoints.env.mask")
 public class PropertySourceMaskingEnvironmentEndpoint extends EnvironmentEndpoint {
 
+	public static final String DEFAULT_MESSAGE = "Properties from this source are redacted for security reasons";
+
 	private String[] sourceNamePatterns = {};
+	
+	private String message = DEFAULT_MESSAGE;
 	
 	/**
 	 * Set patterns to apply against property source names that should be masked.
@@ -39,10 +45,22 @@ public class PropertySourceMaskingEnvironmentEndpoint extends EnvironmentEndpoin
 		return sourceNamePatterns;
 	}
 	
+	/**
+	 * Set the message to include in the environment endpoint response for masked messages.
+	 * @param message The message to include in the environment endpoint response for masked messages.
+	 */
+	public void setMessage(String message) {
+		this.message = message;
+	}
+	
+	public String getMessage() {
+		return message;
+	}
+	
 	@Override
 	protected Map<String, Object> postProcessSourceProperties(String sourceName, Map<String, Object> properties) {
 		if(PatternMatchUtils.simpleMatch(sourceNamePatterns, sourceName)) {
-			properties.replaceAll((key, value) -> "******");
+			return Collections.singletonMap("******", message);
 		}
 		return super.postProcessSourceProperties(sourceName, properties);
 	}

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PropertySourceMaskingEnvironmentEndpoint.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PropertySourceMaskingEnvironmentEndpoint.java
@@ -1,0 +1,50 @@
+package io.pivotal.spring.cloud.service.config;
+
+import java.util.Map;
+
+import org.springframework.boot.actuate.endpoint.EnvironmentEndpoint;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.PatternMatchUtils;
+
+/**
+ * Custom environment endpoint (Actuator) that masks property values for given
+ * property source name patterns. By default, no masking is performed.
+ * 
+ * The property source pattern names can be specified either through the
+ * {@link #setSourceNamePatterns(String...)} method or by setting a
+ * <code>endpoints.env.mask.source-name-patterns</code> property.
+ * 
+ * @author cwalls
+ */
+@ConfigurationProperties(prefix="endpoints.env.mask")
+public class PropertySourceMaskingEnvironmentEndpoint extends EnvironmentEndpoint {
+
+	private String[] sourceNamePatterns = {};
+	
+	/**
+	 * Set patterns to apply against property source names that should be masked.
+	 * Wildcards (*) can be used to apply masking to many similarly named property sources.
+	 * For example, <code>"configService:*"</code> will mask all properties for any
+	 * Spring Cloud Config Service property source. Similarly, <code>"*gi*ub*"</code>
+	 * will mask all property sources that have "gi" and "ub" (including "github") in
+	 * their name.
+	 * 
+	 * @param sourceNamePatterns One or more property source name patterns.
+	 */
+	public void setSourceNamePatterns(String... sourceNamePatterns) {
+		this.sourceNamePatterns = sourceNamePatterns;
+	}
+	
+	public String[] getSourceNamePatterns() {
+		return sourceNamePatterns;
+	}
+	
+	@Override
+	protected Map<String, Object> postProcessSourceProperties(String sourceName, Map<String, Object> properties) {
+		if(PatternMatchUtils.simpleMatch(sourceNamePatterns, sourceName)) {
+			properties.replaceAll((key, value) -> "******");
+		}
+		return super.postProcessSourceProperties(sourceName, properties);
+	}
+	
+}

--- a/spring-cloud-services-spring-connector/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-services-spring-connector/src/main/resources/META-INF/spring.factories
@@ -6,7 +6,8 @@ io.pivotal.spring.cloud.service.hystrix.HystrixStreamServiceConnector
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.pivotal.spring.cloud.service.eureka.EurekaOAuth2AutoConfiguration,\
 io.pivotal.spring.cloud.service.eureka.EurekaInstanceAutoConfiguration,\
-io.pivotal.spring.cloud.service.config.VaultTokenRenewalAutoConfiguration
+io.pivotal.spring.cloud.service.config.VaultTokenRenewalAutoConfiguration,\
+io.pivotal.spring.cloud.service.config.PropertySourceMaskingConfiguration
 
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 io.pivotal.spring.cloud.service.config.ConfigClientOAuth2BootstrapConfiguration,\

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/PropertySourceMaskingEnvironmentEndpointTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/PropertySourceMaskingEnvironmentEndpointTest.java
@@ -1,0 +1,39 @@
+package io.pivotal.spring.cloud.service.config;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class PropertySourceMaskingEnvironmentEndpointTest {
+
+	@Test
+	public void shouldMaskPropertiesThatMatchPattern() {
+		PropertySourceMaskingEnvironmentEndpoint envEndpoint = new PropertySourceMaskingEnvironmentEndpoint();
+		envEndpoint.setSourceNamePatterns("configService:vault:*");
+		
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("abc", "123456");
+		properties.put("def", "987654");
+		envEndpoint.postProcessSourceProperties("configService:vault:game", properties);
+		
+		assertEquals("******", properties.get("abc"));
+		assertEquals("******", properties.get("def"));
+	}
+	
+	@Test
+	public void shouldMaskPropertiesThatDontMatchPattern() {
+		PropertySourceMaskingEnvironmentEndpoint envEndpoint = new PropertySourceMaskingEnvironmentEndpoint();
+		envEndpoint.setSourceNamePatterns("configService:vault:*");
+		
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("abc", "123456");
+		properties.put("def", "987654");
+		envEndpoint.postProcessSourceProperties("configService:https://github.com/test-org/test-config/application.yml", properties);
+		
+		assertEquals("123456", properties.get("abc"));
+		assertEquals("987654", properties.get("def"));
+	}
+}

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/PropertySourceMaskingEnvironmentEndpointTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/PropertySourceMaskingEnvironmentEndpointTest.java
@@ -17,23 +17,38 @@ public class PropertySourceMaskingEnvironmentEndpointTest {
 		Map<String, Object> properties = new HashMap<>();
 		properties.put("abc", "123456");
 		properties.put("def", "987654");
-		envEndpoint.postProcessSourceProperties("configService:vault:game", properties);
+		Map<String, Object> processedProperties = envEndpoint.postProcessSourceProperties("configService:vault:game", properties);
 		
-		assertEquals("******", properties.get("abc"));
-		assertEquals("******", properties.get("def"));
+		assertEquals(1, processedProperties.size());
+		assertEquals(PropertySourceMaskingEnvironmentEndpoint.DEFAULT_MESSAGE, processedProperties.get("******"));
 	}
 	
 	@Test
-	public void shouldMaskPropertiesThatDontMatchPattern() {
+	public void shouldMaskPropertiesThatMatchPatternWithCustomMessage() {
+		PropertySourceMaskingEnvironmentEndpoint envEndpoint = new PropertySourceMaskingEnvironmentEndpoint();
+		envEndpoint.setSourceNamePatterns("configService:vault:*");
+		envEndpoint.setMessage("No properties for you");
+		
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("abc", "123456");
+		properties.put("def", "987654");
+		Map<String, Object> processedProperties = envEndpoint.postProcessSourceProperties("configService:vault:game", properties);
+		
+		assertEquals(1, processedProperties.size());
+		assertEquals("No properties for you", processedProperties.get("******"));
+	}
+	
+	@Test
+	public void shouldNotMaskPropertiesThatDoNotMatchPattern() {
 		PropertySourceMaskingEnvironmentEndpoint envEndpoint = new PropertySourceMaskingEnvironmentEndpoint();
 		envEndpoint.setSourceNamePatterns("configService:vault:*");
 		
 		Map<String, Object> properties = new HashMap<>();
 		properties.put("abc", "123456");
 		properties.put("def", "987654");
-		envEndpoint.postProcessSourceProperties("configService:https://github.com/test-org/test-config/application.yml", properties);
+		Map<String, Object> processedProperties = envEndpoint.postProcessSourceProperties("configService:https://github.com/test-org/test-config/application.yml", properties);
 		
-		assertEquals("123456", properties.get("abc"));
-		assertEquals("987654", properties.get("def"));
+		assertEquals("123456", processedProperties.get("abc"));
+		assertEquals("987654", processedProperties.get("def"));
 	}
 }


### PR DESCRIPTION
Note that this also bumps source compatibility up to Java 1.8 (agreed upon with Scott after a brief Slack discussion). This was done to keep the code a bit neater with the use of a lambda.

Also note that although the goal was to mask properties for Vault property sources, I purposefully wrote the actual extension of EnvironmentEndpoint to be more generic and accept any patterns for sanitization. I put the Vault specific bits in the auto-configuration. This can be overridden by setting a property named `endpoints.env.mask.sourceNamePatterns` (or an equivalent environment variable).