### PR TITLE
Support for plain-text files in config client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,7 @@ project(":spring-cloud-services-spring-connector") {
 		testCompile("org.springframework.cloud:spring-cloud-netflix-hystrix-stream")
 		testCompile("org.springframework.cloud:spring-cloud-starter-stream-rabbit")
 		testCompile("org.springframework.cloud:spring-cloud-starter-ribbon")
+		testCompile("org.springframework.cloud:spring-cloud-config-server")
 		testCompile("commons-logging:commons-logging")
 	}
 }

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PlainTextConfigClient.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PlainTextConfigClient.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pivotal.spring.cloud.service.config;
+
+import org.springframework.core.io.Resource;
+import org.springframework.web.client.HttpClientErrorException;
+
+/**
+ * Provides access to plain text configuration files served by a Spring Cloud Config
+ * Server.
+ *
+ * @author Daniel Lavoie
+ */
+public interface PlainTextConfigClient {
+	/**
+	 * Retrieves a config file using the defaults profiles and labels.
+	 * @param path config file name
+	 * @throws IllegalArgumentException when application name or Config Server url is
+	 * undefined.
+	 * @throws HttpClientErrorException when a config file is not found.
+	 */
+	Resource getConfigFile(String path);
+
+	/**
+	 * Retrieves a config file.
+	 * 
+	 * @throws IllegalArgumentException when application name or Config Server url is
+	 * undefined.
+	 * @throws HttpClientErrorException when a config file is not found.
+	 */
+	Resource getConfigFile(String profile, String label, String path);
+}

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PlainTextConfigClientAutoConfiguration.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PlainTextConfigClientAutoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pivotal.spring.cloud.service.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.config.client.ConfigClientProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+
+/**
+ * Auto configures a {@link PlainTextOAuth2ConfigClient} when a
+ * {@link ConfigClientOAuth2ResourceDetails} and a {@link PlainTextConfigClient} are
+ * available in the container.
+ *
+ * @author Daniel Lavoie
+ */
+@Configuration
+@ConditionalOnClass(OAuth2ProtectedResourceDetails.class)
+public class PlainTextConfigClientAutoConfiguration {
+
+	@Bean
+	@ConditionalOnBean(ConfigClientOAuth2ResourceDetails.class)
+	@ConditionalOnMissingBean(PlainTextConfigClient.class)
+	public PlainTextConfigClient plainTextConfigClient(
+			ConfigClientOAuth2ResourceDetails resource,
+			ConfigClientProperties configClientProperties) {
+		return new PlainTextOAuth2ConfigClient(resource, configClientProperties);
+	}
+}

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PlainTextOAuth2ConfigClient.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PlainTextOAuth2ConfigClient.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pivotal.spring.cloud.service.config;
+
+import org.springframework.cloud.config.client.ConfigClientProperties;
+import org.springframework.core.io.Resource;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * {@link OAuth2RestTemplate} based implementation of {@link PlainTextConfigClient}.
+ * Config Server URI, default application name, profiles and labels are provided by
+ * {@link ConfigClientProperties}.
+ * 
+ * <p>
+ * This client requires an {@link OAuth2ProtectedResourceDetails} holding the Config
+ * Server credentials configurations.
+ * </p>
+ * 
+ * @author Daniel Lavoie
+ */
+class PlainTextOAuth2ConfigClient implements PlainTextConfigClient {
+	private final ConfigClientProperties configClientProperties;
+
+	private RestTemplate restTemplate;
+
+	protected PlainTextOAuth2ConfigClient(final OAuth2ProtectedResourceDetails resource,
+			final ConfigClientProperties configClientProperties) {
+		this.restTemplate = new OAuth2RestTemplate(resource);
+
+		this.configClientProperties = configClientProperties;
+	}
+
+	/**
+	 * Retrieves a config file using the defaults application name, profiles and labels.
+	 * 
+	 * @throws IllegalArgumentException when application name or Config Server url
+	 * is undefined.
+	 * @throws HttpClientErrorException when a config file is not found.
+	 */
+	@Override
+	public Resource getConfigFile(String path) {
+		return getConfigFile(null, null, path);
+	}
+
+	/**
+	 * Retrieves a config file.
+	 * 
+	 * @throws IllegalArgumentException when application name or Config Server url
+	 * is undefined.
+	 * @throws HttpClientErrorException when a config file is not found.
+	 */
+	@Override
+	public Resource getConfigFile(String profile, String label, String path) {
+		Assert.isTrue(
+				configClientProperties.getName() != null
+						&& !configClientProperties.getName().isEmpty(),
+				"Spring application name is undefined.");
+
+		Assert.isTrue(
+				configClientProperties.getUri() != null
+						&& !configClientProperties.getUri().isEmpty(),
+				"Config server URI is undefined.");
+
+		if (profile == null) {
+			profile = configClientProperties.getProfile();
+			if (profile == null || profile.isEmpty()) {
+				profile = "default";
+			}
+		}
+
+		if (label == null) {
+			label = configClientProperties.getLabel();
+			if (label == null || !label.isEmpty()) {
+				label = "master";
+			}
+		}
+
+		return restTemplate.getForEntity(
+				configClientProperties.getUri() + "/" + configClientProperties.getName()
+						+ "/" + profile + "/" + label + "/" + path,
+				Resource.class).getBody();
+	}
+}

--- a/spring-cloud-services-spring-connector/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-services-spring-connector/src/main/resources/META-INF/spring.factories
@@ -7,7 +7,8 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.pivotal.spring.cloud.service.eureka.EurekaOAuth2AutoConfiguration,\
 io.pivotal.spring.cloud.service.eureka.EurekaInstanceAutoConfiguration,\
 io.pivotal.spring.cloud.service.config.VaultTokenRenewalAutoConfiguration,\
-io.pivotal.spring.cloud.service.config.PropertySourceMaskingConfiguration
+io.pivotal.spring.cloud.service.config.PropertySourceMaskingConfiguration,\
+io.pivotal.spring.cloud.service.config.PlainTextConfigClientAutoConfiguration
 
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 io.pivotal.spring.cloud.service.config.ConfigClientOAuth2BootstrapConfiguration,\

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/ConfigServerServiceConnectorIntegrationTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/ConfigServerServiceConnectorIntegrationTest.java
@@ -45,7 +45,8 @@ import static org.junit.Assert.assertEquals;
 		classes = {
 				ConfigServerServiceConnectorIntegrationTest.TestConfig.class,
 				ConfigClientOAuth2BootstrapConfiguration.class
-		})
+		},
+		properties = "spring.cloud.config.enabled=true")
 public class ConfigServerServiceConnectorIntegrationTest {
 
 	private static final String CLIENT_ID = "client-id";

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/context/DisabledPlainTextConfigClientTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/context/DisabledPlainTextConfigClientTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pivotal.spring.cloud.service.config.client.context;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import io.pivotal.spring.cloud.service.config.PlainTextConfigClient;
+import io.pivotal.spring.cloud.service.config.PlainTextConfigClientAutoConfiguration;
+
+/**
+ * @author Daniel Lavoie
+ */
+@RunWith(SpringRunner.class)
+@Import(PlainTextConfigClientAutoConfiguration.class)
+@SpringBootTest(classes = DisabledPlainTextConfigClientTest.class)
+public class DisabledPlainTextConfigClientTest {
+	@Autowired(required = false)
+	private PlainTextConfigClient plainTextConfigClient;
+
+	@Autowired
+	private Environment environment;
+
+	@Test
+	public void configClientBeanShouldNotBeInjected() {
+		Assert.assertNotNull("Spring container is not initialized.", environment);
+		Assert.assertNull(plainTextConfigClient);
+	}
+}

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/context/PlainTextConfigClientAutoConfigTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/context/PlainTextConfigClientAutoConfigTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pivotal.spring.cloud.service.config.client.context;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import io.pivotal.spring.cloud.service.config.ConfigClientOAuth2ResourceDetails;
+import io.pivotal.spring.cloud.service.config.PlainTextConfigClient;
+import io.pivotal.spring.cloud.service.config.PlainTextConfigClientAutoConfiguration;
+
+/**
+ * @author Daniel Lavoie
+ */
+@SpringBootApplication
+@RunWith(SpringRunner.class)
+@Import({ ConfigClientOAuth2ResourceDetails.class,
+		PlainTextConfigClientAutoConfiguration.class })
+@SpringBootTest(classes = PlainTextConfigClientAutoConfigTest.class)
+public class PlainTextConfigClientAutoConfigTest {
+	@Autowired
+	private PlainTextConfigClient plainTextConfigClient;
+
+	@Test
+	public void contextLoads() {
+		Assert.assertNotNull(plainTextConfigClient);
+	}
+}

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/server/ConfigServerTestApplication.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/server/ConfigServerTestApplication.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pivotal.spring.cloud.service.config.client.server;
+
+import java.security.Principal;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.cloud.config.server.EnableConfigServer;
+import org.springframework.cloud.netflix.metrics.servo.ServoMetricsAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+import org.springframework.security.oauth2.provider.endpoint.TokenEndpoint;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.pivotal.spring.cloud.service.config.ConfigClientOAuth2ResourceDetails;
+import io.pivotal.spring.cloud.service.config.PlainTextConfigClientAutoConfiguration;
+
+/**
+ * @author Daniel Lavoie
+ */
+@RestController
+@EnableConfigServer
+@SpringBootApplication(exclude = { RabbitAutoConfiguration.class,
+		ServoMetricsAutoConfiguration.class })
+@EnableAuthorizationServer
+@Import({ ConfigClientOAuth2ResourceDetails.class,
+		PlainTextConfigClientAutoConfiguration.class })
+@Order(SecurityProperties.ACCESS_OVERRIDE_ORDER)
+public class ConfigServerTestApplication extends WebSecurityConfigurerAdapter {
+	@Autowired
+	private TokenEndpoint tokenEndpoint;
+
+	@PostMapping("/oauth/token")
+	public ResponseEntity<OAuth2AccessToken> getAccessToken(Principal principal,
+			@RequestParam Map<String, String> parameters)
+			throws HttpRequestMethodNotSupportedException {
+		return tokenEndpoint.postAccessToken(principal, parameters);
+	}
+
+	@Configuration
+	@EnableResourceServer
+	protected static class ResourceServerConfiguration
+			extends ResourceServerConfigurerAdapter {
+		@Override
+		public void configure(HttpSecurity http) throws Exception {
+			http.antMatcher("/**").authorizeRequests().anyRequest().authenticated();
+		}
+	}
+}

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/server/PlainTextOauth2ConfigClientTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/server/PlainTextOauth2ConfigClientTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pivotal.spring.cloud.service.config.client.server;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cloud.config.client.ConfigClientProperties;
+import org.springframework.core.io.Resource;
+import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.HttpClientErrorException;
+
+import io.pivotal.spring.cloud.service.config.ConfigClientOAuth2ResourceDetails;
+import io.pivotal.spring.cloud.service.config.PlainTextConfigClient;
+import io.pivotal.spring.cloud.service.config.PlainTextConfigClientAutoConfiguration;
+
+/**
+ * @author Daniel Lavoie
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ConfigServerTestApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, properties = {
+		"spring.profiles.active=plaintext,native", "spring.cloud.config.enabled=true" })
+public class PlainTextOauth2ConfigClientTest {
+	// @formatter:off
+	private static final String nginxConfig = "server {\n"
+			+ "    listen              80;\n"
+			+ "    server_name         example.com;\n"
+			+ "}";
+
+	private static final String devNginxConfig = "server {\n"
+			+ "    listen              80;\n"
+			+ "    server_name         dev.example.com"
+			+ ";\n}";
+
+	private static final String testNginxConfig = "server {\n    listen              80;"
+			+ "\n"
+			+ "    server_name         test.example.com;"
+			+ "\n}";
+	// @formatter:on 
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private ConfigClientOAuth2ResourceDetails resource;
+
+	@Autowired
+	private ConfigClientProperties configClientProperties;
+
+	private PlainTextConfigClient configClient;
+
+	@Before
+	public void setup() {
+		resource.setAccessTokenUri("http://localhost:" + port + "/oauth/token");
+		configClientProperties.setName("app");
+		configClientProperties.setUri("http://localhost:" + port);
+		configClient = new PlainTextConfigClientAutoConfiguration()
+				.plainTextConfigClient(resource, configClientProperties);
+	}
+
+	@Test
+	public void shouldFindSimplePlainFile() {
+		Assert.assertEquals(nginxConfig,
+				read(configClient.getConfigFile(null, null, "nginx.conf")));
+
+		Assert.assertEquals(devNginxConfig,
+				read(configClient.getConfigFile("dev", "master", "nginx.conf")));
+
+		configClientProperties.setProfile("test");
+		Assert.assertEquals(testNginxConfig,
+				read(configClient.getConfigFile("nginx.conf")));
+	}
+
+	@Test(expected = HttpClientErrorException.class)
+	public void missingConfigFileShouldReturnHttpError() {
+		configClient.getConfigFile("missing-config.xml");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void missingApplicationNameShouldCrash() {
+		configClientProperties.setName("");
+		configClient.getConfigFile("nginx.conf");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void missingConfigServerUrlShouldCrash() {
+		configClientProperties.setUri("");
+		configClient.getConfigFile("nginx.conf");
+	}
+
+	@Test(expected = OAuth2AccessDeniedException.class)
+	public void shouldBeDenied() {
+		ConfigClientOAuth2ResourceDetails invalidCrendentialsResource = new ConfigClientOAuth2ResourceDetails();
+		invalidCrendentialsResource.setClientId("wrongClient");
+		invalidCrendentialsResource.setAccessTokenUri(resource.getAccessTokenUri());
+		invalidCrendentialsResource.setClientSecret("wrongsecret");
+		invalidCrendentialsResource.setScope(resource.getScope());
+		invalidCrendentialsResource.setGrantType(resource.getGrantType());
+
+		new PlainTextConfigClientAutoConfiguration()
+				.plainTextConfigClient(invalidCrendentialsResource,
+						configClientProperties)
+				.getConfigFile("nginx.conf");
+	}
+
+	public String read(Resource resource) {
+		try (BufferedReader buffer = new BufferedReader(
+				new InputStreamReader(resource.getInputStream()))) {
+			return buffer.lines().collect(Collectors.joining("\n"));
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/spring-cloud-services-spring-connector/src/test/resources/application-plaintext.yml
+++ b/spring-cloud-services-spring-connector/src/test/resources/application-plaintext.yml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: test-app
+    
+  cloud:
+    config:
+      client:
+        oauth2:
+          client-id: acme
+          client-secret: acmesecret
+          scope: read,write
+          auto-approve-scopes: '.*'
+          grant-type: client_credentials
+
+security:
+  oauth2:
+    client:
+      client-id: acme
+      client-secret: acmesecret
+      scope: read,write
+      auto-approve-scopes: '.*'
+      grant-type: client_credentials

--- a/spring-cloud-services-spring-connector/src/test/resources/application.yml
+++ b/spring-cloud-services-spring-connector/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: native

--- a/spring-cloud-services-spring-connector/src/test/resources/config/nginx-dev.conf
+++ b/spring-cloud-services-spring-connector/src/test/resources/config/nginx-dev.conf
@@ -1,0 +1,4 @@
+server {
+    listen              80;
+    server_name         dev.example.com;
+}

--- a/spring-cloud-services-spring-connector/src/test/resources/config/nginx-test.conf
+++ b/spring-cloud-services-spring-connector/src/test/resources/config/nginx-test.conf
@@ -1,0 +1,4 @@
+server {
+    listen              80;
+    server_name         test.example.com;
+}

--- a/spring-cloud-services-spring-connector/src/test/resources/config/nginx.conf
+++ b/spring-cloud-services-spring-connector/src/test/resources/config/nginx.conf
@@ -1,0 +1,4 @@
+server {
+    listen              80;
+    server_name         example.com;
+}


### PR DESCRIPTION
Provides a new auto configured PlainTextConfigClient.

#### Config Server Client Configuration

This new feature leverages the auto-configuration of the Config Client made by Spring Cloud Services Connector. If `VCAP_APPLICATION` and `VCAP_SERVICES` are available in the container, the `ConfigClientOAuth2BootstrapConfiguration` will set up a `ConfigClientOAuth2ResourceDetails` with the credentials captures from the env variables.  The new auto-configuration for this plain text client will fire up if this `ResourceDetails` bean is present.

##### PlainTextConfigClient

New API that provides abstraction over the implementation of the plain text config client. The API should support `applicationName`, `profile` and `label` defaulting based on the ones configured for the application.  

##### PlainTextOAuth2ConfigClient

`OAuth2RestTemplate` based implementation of `PlainTextConfigClient`. Expects to be instantiated with an `OAuth2ProtectedResourceDetails` containing the Oauth2 credential infos for the Config Server.
