### PR TITLE
Don't suppress Rabbit autoconfig when bound to RMQ

### DIFF
--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/config/java/ServiceInfoPropertySourceAdapter.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/config/java/ServiceInfoPropertySourceAdapter.java
@@ -2,6 +2,8 @@ package io.pivotal.spring.cloud.config.java;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.cloud.Cloud;
 import org.springframework.cloud.CloudException;
@@ -84,8 +86,11 @@ public abstract class ServiceInfoPropertySourceAdapter<T extends ServiceInfo>
 	}
 
 	private boolean appIsBoundToRabbitMQ() {
-		return environment.containsProperty("spring.rabbitmq.host") &&
+		boolean hasEnvironmentBinding = environment.containsProperty("spring.rabbitmq.host") &&
 				!environment.getProperty("spring.rabbitmq.host").equals("localhost");
+		boolean hasCloudBinding = !cloud.getServiceInfos(ConnectionFactory.class).isEmpty();
+
+		return hasEnvironmentBinding || hasCloudBinding;
 	}
 
 	@Override


### PR DESCRIPTION
There's some detailed discussion on this in GitHub issue #36.

We have some logic in the connector which tries to disable the standard
Boot RabbitMQ autoconfiguration in cases where it's not needed. Rabbit
always ends up on the classpath due to our transitive dependencies for Hystrix,
but if there's no user-configured RMQ instance to connect to, the
resulting autoconfiguration means we end up with a failing healthcheck.

In a cloud environment, Spring Cloud Connectors provide a Rabbit connection
factory if the app is bound to a Rabbit service instance. But there are other
beans provided by the standard Boot autoconfiguration that an app could still
depend on. These end up missing from the application context because the
conditions for our autoconfig supression logic were still being met.

This commit makes the suppression logic cloud aware. Now we allow the
default Boot Rabbit autoconfig to run if _either_ the user has
configured a Rabbit binding through the environment, _or_ the cloud
environment is providing a Rabbit service binding. This should fix the
missing beans issues.

[finishes #155640825]