### PR TITLE
Improve PlainTextConfigClientAutoConfiguration

### DIFF
--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/ConfigClientOAuth2BootstrapConfiguration.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/ConfigClientOAuth2BootstrapConfiguration.java
@@ -35,17 +35,11 @@ import org.springframework.util.Assert;
  * @author Will Tran
  */
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties(ConfigClientOAuth2ResourceDetails.class)
 @ConditionalOnClass({ConfigServicePropertySourceLocator.class, OAuth2RestTemplate.class})
 @ConditionalOnProperty(value = "spring.cloud.config.client.oauth2.clientId")
 public class ConfigClientOAuth2BootstrapConfiguration {
 
-	@Bean
-	@ConditionalOnMissingBean(ConfigClientOAuth2ResourceDetails.class)
-	public ConfigClientOAuth2ResourceDetails configClientOAuth2ResourceDetails() {
-		return new ConfigClientOAuth2ResourceDetails();
-	}
-	
 	@Configuration
 	public class ConfigClientOAuth2Configurer {
 
@@ -67,6 +61,5 @@ public class ConfigClientOAuth2BootstrapConfiguration {
 		}
 
 	}
-	
 
 }

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PlainTextConfigClientAutoConfiguration.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PlainTextConfigClientAutoConfiguration.java
@@ -16,9 +16,10 @@
 
 package io.pivotal.spring.cloud.service.config;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.config.client.ConfigClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,15 +31,19 @@ import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResour
  * available in the container.
  *
  * @author Daniel Lavoie
+ * @author Roy Clarkson
  */
 @Configuration
 @ConditionalOnClass({ OAuth2ProtectedResourceDetails.class,
 		ConfigClientProperties.class })
+@EnableConfigurationProperties({ ConfigClientOAuth2ResourceDetails.class,
+		ConfigClientProperties.class })
 public class PlainTextConfigClientAutoConfiguration {
 
 	@Bean
-	@ConditionalOnBean(ConfigClientOAuth2ResourceDetails.class)
 	@ConditionalOnMissingBean(PlainTextConfigClient.class)
+	@ConditionalOnProperty(prefix = "spring.cloud.config.client.oauth2", name = {
+			"client-id", "client-secret" })
 	public PlainTextConfigClient plainTextConfigClient(
 			ConfigClientOAuth2ResourceDetails resource,
 			ConfigClientProperties configClientProperties) {

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/server/ConfigServerTestApplication.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/server/ConfigServerTestApplication.java
@@ -26,7 +26,6 @@ import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.cloud.config.server.EnableConfigServer;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -41,9 +40,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.pivotal.spring.cloud.service.config.ConfigClientOAuth2ResourceDetails;
-import io.pivotal.spring.cloud.service.config.PlainTextConfigClientAutoConfiguration;
-
 /**
  * @author Daniel Lavoie
  */
@@ -51,8 +47,6 @@ import io.pivotal.spring.cloud.service.config.PlainTextConfigClientAutoConfigura
 @EnableConfigServer
 @SpringBootApplication(exclude = { RabbitAutoConfiguration.class})
 @EnableAuthorizationServer
-@Import({ ConfigClientOAuth2ResourceDetails.class,
-		PlainTextConfigClientAutoConfiguration.class })
 @Order(SecurityProperties.BASIC_AUTH_ORDER - 2)
 public class ConfigServerTestApplication extends WebSecurityConfigurerAdapter {
 


### PR DESCRIPTION
The ConfigClientOAuth2ResourceDetails bean wasn’t being handled as
well as it could be. It should be created in
@EnableConfiguratProperties, since it’s instantiated from properties.
Using @Import in the tests was also instantiating this bean, which
wasn’t properly testing the autoconfig scenarios.

Resolves #62