### PR TITLE
Fix for config-client auto-configuration.

### DIFF
--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/ConfigClientOAuth2BootstrapConfiguration.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/ConfigClientOAuth2BootstrapConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.util.Assert;
 @Configuration
 @EnableConfigurationProperties(ConfigClientOAuth2ResourceDetails.class)
 @ConditionalOnClass({ConfigServicePropertySourceLocator.class, OAuth2RestTemplate.class})
-@ConditionalOnProperty(value = "spring.cloud.config.client.oauth2.clientId")
+@ConditionalOnProperty(value = "spring.cloud.config.client.oauth2.client-id")
 public class ConfigClientOAuth2BootstrapConfiguration {
 
 	@Configuration

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PlainTextConfigClientAutoConfiguration.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/service/config/PlainTextConfigClientAutoConfiguration.java
@@ -16,10 +16,11 @@
 
 package io.pivotal.spring.cloud.service.config;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.config.client.ConfigClientAutoConfiguration;
 import org.springframework.cloud.config.client.ConfigClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -36,8 +37,9 @@ import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResour
 @Configuration
 @ConditionalOnClass({ OAuth2ProtectedResourceDetails.class,
 		ConfigClientProperties.class })
-@EnableConfigurationProperties({ ConfigClientOAuth2ResourceDetails.class,
-		ConfigClientProperties.class })
+// @EnableConfigurationProperties(ConfigClientOAuth2ResourceDetails.class)
+@AutoConfigureAfter({ ConfigClientAutoConfiguration.class,
+		ConfigClientOAuth2BootstrapConfiguration.class })
 public class PlainTextConfigClientAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/context/PlainTextConfigClientAutoConfigTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/context/PlainTextConfigClientAutoConfigTest.java
@@ -18,26 +18,31 @@ package io.pivotal.spring.cloud.service.config.client.context;
 
 import org.junit.Test;
 
+import io.pivotal.spring.cloud.service.config.ConfigClientOAuth2BootstrapConfiguration;
 import io.pivotal.spring.cloud.service.config.ConfigClientOAuth2ResourceDetails;
 import io.pivotal.spring.cloud.service.config.PlainTextConfigClient;
 import io.pivotal.spring.cloud.service.config.PlainTextConfigClientAutoConfiguration;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.cloud.config.client.ConfigClientAutoConfiguration;
 import org.springframework.cloud.config.client.ConfigClientProperties;
+import org.springframework.cloud.config.client.ConfigServiceBootstrapConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PlainTextConfigClientAutoConfigTest {
 
 	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(PlainTextConfigClientAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(PlainTextConfigClientAutoConfiguration.class,
+					ConfigClientAutoConfiguration.class, ConfigClientOAuth2BootstrapConfiguration.class,
+					ConfigServiceBootstrapConfiguration.class));
 
 	@Test
 	public void plainTextConfigClientIsNotCreated() throws Exception {
 		this.contextRunner
 				.run(context -> {
-					assertThat(context).hasSingleBean(ConfigClientOAuth2ResourceDetails.class);
+					assertThat(context).doesNotHaveBean(ConfigClientOAuth2ResourceDetails.class);
 					assertThat(context).hasSingleBean(ConfigClientProperties.class);
 					assertThat(context).doesNotHaveBean(PlainTextConfigClient.class);
 				});

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/server/PlainTextDefaultLabelTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/server/PlainTextDefaultLabelTest.java
@@ -27,6 +27,7 @@ import io.pivotal.spring.cloud.service.config.PlainTextConfigClientAutoConfigura
 		"spring.profiles.active=plaintext,native,integration-test",
 		"spring.cloud.config.enabled=true",
 		"eureka.client.enabled=false",
+		"spring.cloud.config.client.oauth2.client-id=acme"
 })
 public class PlainTextDefaultLabelTest {
 

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/server/PlainTextOauth2ConfigClientTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/client/server/PlainTextOauth2ConfigClientTest.java
@@ -45,7 +45,8 @@ import io.pivotal.spring.cloud.service.config.PlainTextConfigClientAutoConfigura
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ConfigServerTestApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, properties = {
-		"spring.profiles.active=plaintext,native", "spring.cloud.config.enabled=true", "eureka.client.enabled=false" })
+		"spring.profiles.active=plaintext,native", "spring.cloud.config.enabled=true", "eureka.client.enabled=false",
+		"spring.cloud.config.client.oauth2.client-id=acme"})
 public class PlainTextOauth2ConfigClientTest {
 	// @formatter:off
 	private static final String nginxConfig = "server {\n"


### PR DESCRIPTION
Fix auto-configuration problems around `ConfigClientProperties` being created twice.