### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,9 +70,9 @@ allprojects {
 	}
 
 	ext.javadocLinks = [
-			'http://docs.oracle.com/javase/8/docs/api/',
-			'http://docs.oracle.com/javaee/7/api/',
-			'http://docs.spring.io/spring/docs/current/javadoc-api/',
+			'https://docs.oracle.com/javase/8/docs/api/',
+			'https://docs.oracle.com/javaee/7/api/',
+			'https://docs.spring.io/spring/docs/current/javadoc-api/',
 	] as String[]
 }
 

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -30,12 +30,12 @@ def customizePom(pom, gradleProject) {
 			url = "https://github.com/pivotal-cf/spring-cloud-services-connector"
 			organization {
 				name = "Spring IO"
-				url = "http://projects.spring.io/spring-cloud"
+				url = "https://projects.spring.io/spring-cloud"
 			}
 			licenses {
 				license {
 					name "The Apache Software License, Version 2.0"
-					url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+					url "https://www.apache.org/licenses/LICENSE-2.0.txt"
 					distribution "repo"
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javaee/7/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javaee/7/api/ ([https](https://docs.oracle.com/javaee/7/api/) result 200).
* http://docs.oracle.com/javase/8/docs/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/8/docs/api/ ([https](https://docs.oracle.com/javase/8/docs/api/) result 200).
* http://docs.spring.io/spring/docs/current/javadoc-api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/ ([https](https://docs.spring.io/spring/docs/current/javadoc-api/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://projects.spring.io/spring-cloud with 1 occurrences migrated to:  
  https://projects.spring.io/spring-cloud ([https](https://projects.spring.io/spring-cloud) result 301).