### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@ image:https://build.spring.io/plugins/servlet/wittified/build-status/CLOUD-SCPC[
 
 = Spring Cloud Services Connector
 
-link:http://cloud.spring.io/spring-cloud-connectors/[Spring Cloud Connectors] for link:http://docs.pivotal.io/spring-cloud-services/index.html[Spring Cloud Services] in a link:http://pivotal.io/platform[Pivotal Cloud Foundry] environment
+link:https://cloud.spring.io/spring-cloud-connectors/[Spring Cloud Connectors] for link:https://docs.pivotal.io/spring-cloud-services/index.html[Spring Cloud Services] in a link:https://pivotal.io/platform[Pivotal Cloud Foundry] environment
 
 - Config Server
 - Circuit Breaker (Netflix Hystrix)

--- a/spring-cloud-services-cloudfoundry-connector/src/test/resources/io/pivotal/spring/cloud/cloudfoundry/test-hystrix-amqp-info.json
+++ b/spring-cloud-services-cloudfoundry-connector/src/test/resources/io/pivotal/spring/cloud/cloudfoundry/test-hystrix-amqp-info.json
@@ -14,10 +14,10 @@
       "vhost": "$virtualHost"
     },
     "dashboard": {
-      "uri": "http://username:password@hystrix-69a9789a-5df8-49d4-b6d4-81973f076f4e.apps.example.com"
+      "uri": "https://username:password@hystrix-69a9789a-5df8-49d4-b6d4-81973f076f4e.apps.example.com"
     },
     "stream": {
-      "uri": "http://turbine-69a9789a-5df8-49d4-b6d4-81973f076f4e.apps.example.com"
+      "uri": "https://turbine-69a9789a-5df8-49d4-b6d4-81973f076f4e.apps.example.com"
     }
   }
 }

--- a/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/config/java/ServiceInfoPropertySourceAdapter.java
+++ b/spring-cloud-services-spring-connector/src/main/java/io/pivotal/spring/cloud/config/java/ServiceInfoPropertySourceAdapter.java
@@ -21,8 +21,8 @@ import org.springframework.core.env.PropertySource;
  * @author Scott Frederick
  * @author Will Tran
  * @see <a href=
- * "http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config">
- * http://docs.spring.io/spring-boot/docs/current/reference/html/boot-
+ * "https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config">
+ * https://docs.spring.io/spring-boot/docs/current/reference/html/boot-
  * features-external-config.html#boot-features-external-config</a>
  */
 public abstract class ServiceInfoPropertySourceAdapter<T extends ServiceInfo>

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/ConfigServerServiceConnectorIntegrationTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/config/ConfigServerServiceConnectorIntegrationTest.java
@@ -56,7 +56,7 @@ public class ConfigServerServiceConnectorIntegrationTest {
 
 	private static final String ACCESS_TOKEN_URI = "https://your-identity-zone.uaa.my-cf.com/oauth/token";
 
-	private static final String URI = "http://username:password@config-server.mydomain.com";
+	private static final String URI = "https://username:password@config-server.mydomain.com";
 
 	@Autowired
 	private Environment environment;

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/hystrix/HystrixStreamServiceConnectorIntegrationMultiUriTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/hystrix/HystrixStreamServiceConnectorIntegrationMultiUriTest.java
@@ -63,7 +63,7 @@ public class HystrixStreamServiceConnectorIntegrationMultiUriTest {
 		when(MockCloudConnector.instance.getServiceInfos()).thenReturn(
 				Arrays.asList(
 						(ServiceInfo) new HystrixAmqpServiceInfo("circuit-breaker", URI, URIS, true),
-						(ServiceInfo) new EurekaServiceInfo("service-registry", "http://example.com", "clientId", "clientSecret", "http://example.com/token")
+						(ServiceInfo) new EurekaServiceInfo("service-registry", "https://example.com", "clientId", "clientSecret", "https://example.com/token")
 				)
 		);
 	}

--- a/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/hystrix/HystrixStreamServiceConnectorIntegrationTest.java
+++ b/spring-cloud-services-spring-connector/src/test/java/io/pivotal/spring/cloud/service/hystrix/HystrixStreamServiceConnectorIntegrationTest.java
@@ -123,7 +123,7 @@ public class HystrixStreamServiceConnectorIntegrationTest {
 			when(MockCloudConnector.instance.getServiceInfos()).thenReturn(
 					Arrays.asList(
 							new HystrixAmqpServiceInfo("circuit-breaker", URI),
-							new EurekaServiceInfo("service-registry", "http://example.com", "clientId", "clientSecret", "http://example.com/token")
+							new EurekaServiceInfo("service-registry", "https://example.com", "clientId", "clientSecret", "https://example.com/token")
 					)
 			);
 		}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://turbine-69a9789a-5df8-49d4-b6d4-81973f076f4e.apps.example.com (UnknownHostException) with 1 occurrences migrated to:  
  https://turbine-69a9789a-5df8-49d4-b6d4-81973f076f4e.apps.example.com ([https](https://turbine-69a9789a-5df8-49d4-b6d4-81973f076f4e.apps.example.com) result UnknownHostException).
* http://username:password@config-server.mydomain.com (UnknownHostException) with 1 occurrences migrated to:  
  https://username:password@config-server.mydomain.com ([https](https://username:password@config-server.mydomain.com) result UnknownHostException).
* http://username:password@hystrix-69a9789a-5df8-49d4-b6d4-81973f076f4e.apps.example.com (UnknownHostException) with 1 occurrences migrated to:  
  https://username:password@hystrix-69a9789a-5df8-49d4-b6d4-81973f076f4e.apps.example.com ([https](https://username:password@hystrix-69a9789a-5df8-49d4-b6d4-81973f076f4e.apps.example.com) result UnknownHostException).
* http://docs.spring.io/spring-boot/docs/current/reference/html/boot- (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/boot- ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-) result 404).
* http://example.com/token (404) with 2 occurrences migrated to:  
  https://example.com/token ([https](https://example.com/token) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://cloud.spring.io/spring-cloud-connectors/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/ ([https](https://cloud.spring.io/spring-cloud-connectors/) result 200).
* http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html) result 200).
* http://example.com with 2 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* http://pivotal.io/platform with 1 occurrences migrated to:  
  https://pivotal.io/platform ([https](https://pivotal.io/platform) result 200).
* http://docs.pivotal.io/spring-cloud-services/index.html with 1 occurrences migrated to:  
  https://docs.pivotal.io/spring-cloud-services/index.html ([https](https://docs.pivotal.io/spring-cloud-services/index.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 6 occurrences